### PR TITLE
fixes #43

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -284,5 +284,7 @@ read_globals = {
 	"ChatFrameToggleVoiceMuteButton",
 	"ChatFrameChannelButton",
 	"UnitReaction",
-	"PixelUtil"
+	"PixelUtil",
+	"GameTooltipTextLeft4",
+	"GameTooltipTextLeft5"
 }

--- a/modules/tooltips/tooltips.lua
+++ b/modules/tooltips/tooltips.lua
@@ -75,11 +75,9 @@ GameTooltip:HookScript("OnTooltipSetUnit", function(self,...)
 			difficultyColor = GetQuestDifficultyColor(level)
 		end
 		left[line]:SetFormattedText('|cff%02x%02x%02x%s|r %s', difficultyColor.r*255, difficultyColor.g*255, difficultyColor.b*255, level, race)
-		line = line + 1
 
-		for i = line, GameTooltip:NumLines() do
-			left[i]:SetText(nil)
-		end
+		GameTooltipTextLeft4:SetText(nil)
+		GameTooltipTextLeft5:SetText(nil)
 	else
 		local name = UnitName(unit)
 		left[line]:SetText(name)


### PR DESCRIPTION
RaiderIO tooltips were broken. No longer. This is probably true for any other addon that touches tooltips.